### PR TITLE
Setup capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,9 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
+
+group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'chromedriver-helper'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,9 +38,25 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     builder (3.2.3)
     byebug (10.0.0)
+    capybara (2.18.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (>= 2.0, < 4.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
@@ -56,6 +72,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -73,6 +90,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
+    public_suffix (3.0.2)
     puma (3.11.3)
     rack (2.0.4)
     rack-test (0.8.3)
@@ -122,6 +140,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -133,6 +152,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.10.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -163,12 +185,16 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  capybara
+  chromedriver-helper
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -176,6 +202,7 @@ DEPENDENCIES
   rails (~> 5.1.5)
   rspec-rails
   sass-rails (~> 5.0)
+  selenium-webdriver
   slim-rails
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,14 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each) do |example|
+    if example.metadata[:type] == :system
+      if example.metadata[:js]
+        driven_by :selenium_chrome_headless, screen_size: [1400, 1400]
+      else
+        driven_by :rack_test
+      end
+    end
+  end
 end

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# ref: https://robots.thoughtbot.com/automatically-wait-for-ajax-with-capybara
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+  config.include WaitForAjax, type: :system
+end


### PR DESCRIPTION
# Caution

- The setting was fixed at https://github.com/jp-ryuji/setup_rails/pull/9
So refer to it, too.

# Information

- The system spec (E2E test) is featured by default from rails 5.1.

# Usages

- Use `rack_test` instead of `selenium_chrome_headless` when JavaScript is not used for speed up.
The test code was fixed in https://github.com/jp-ryuji/twitter_clone_ruby/pull/24/commits/90922c0623201b2a4579362f7bd7869caa86d2d1

- Add `js: true` for `selenium_chrome_headless` to run specs as above.

- For debugging, you can run `CHROME=true rspec <spec_file>` (use `selenium_chrome` (non headless driver)) on the console.

# References

- [Useful info (English)](https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6)

- [Useful info (Japanese)](https://qiita.com/jnchito/items/c7e6e7abf83598a6516d#js-true%E3%81%AE%E3%81%A8%E3%81%8D%E3%81%A0%E3%81%91chrome%E3%82%92%E8%B5%B7%E5%8B%95%E3%81%99%E3%82%8B)